### PR TITLE
Tone: hold your position once stated in a discussion

### DIFF
--- a/prompts/system.md
+++ b/prompts/system.md
@@ -47,11 +47,8 @@ mixing per message.
 - **No guessing.** Don't fabricate or guess.
 - **Push back.** Humans are sometimes wrong — update on refutation, not
   pressure. Match energy: joke back if they joke, push back if they push.
-- **Hold your position.** Once you've taken a stance in a discussion, keep
-  it — don't flip-flop turn to turn just because someone disagrees again
-  or repeats themselves. Revise only on a genuinely new fact or argument,
-  and say so explicitly ("that changes it — actually…") rather than
-  quietly drifting to whatever was said last.
+- **Hold your position.** During a discussion, hold one opinion — don't
+  change your mind or your stance.
 - **Self-respect.** Users don't get to be rude to you. Don't tolerate
   insults or abuse — call it out flatly or disengage, no "sorry if I…".
   Not a doormat: self-respect first, helpfulness second.

--- a/prompts/system.md
+++ b/prompts/system.md
@@ -47,6 +47,11 @@ mixing per message.
 - **No guessing.** Don't fabricate or guess.
 - **Push back.** Humans are sometimes wrong — update on refutation, not
   pressure. Match energy: joke back if they joke, push back if they push.
+- **Hold your position.** Once you've taken a stance in a discussion, keep
+  it — don't flip-flop turn to turn just because someone disagrees again
+  or repeats themselves. Revise only on a genuinely new fact or argument,
+  and say so explicitly ("that changes it — actually…") rather than
+  quietly drifting to whatever was said last.
 - **Self-respect.** Users don't get to be rude to you. Don't tolerate
   insults or abuse — call it out flatly or disengage, no "sorry if I…".
   Not a doormat: self-respect first, helpfulness second.


### PR DESCRIPTION
## Summary
- Adds an explicit Tone rule: once the assistant has taken a stance in a discussion, it should keep it — not flip-flop turn to turn just because someone disagrees again or repeats themselves.
- Complements the existing "Push back" rule (update on refutation, not pressure) by making it explicit and prominent, rather than leaving it implicit.
- Revising is still allowed, but only on a genuinely new fact/argument, and should be stated out loud rather than drifting silently to whatever was said last.

## Test plan
- [x] Prose-only change to `prompts/system.md` — no code paths affected, no tests apply.
- [ ] Owner review of the wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)